### PR TITLE
[SCAL-4767] Pin Alpine version to address missing aws-cli in v3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.19
 
 RUN apk --update --no-cache add git aws-cli
 


### PR DESCRIPTION
![image](https://github.com/scalartech/sync-up-to-codecommit-action/assets/73839068/d166b43d-4c77-4885-8bc7-3522fdc39de1)
